### PR TITLE
Strip cegcc bin

### DIFF
--- a/scripts/build_cegcc.bash
+++ b/scripts/build_cegcc.bash
@@ -17,6 +17,10 @@ mkdir -p ${WORKSPACE}/cegcc-working
 cd ${WORKSPACE}/cegcc-working
 ${WORKSPACE}/cegcc-build/build.sh --prefix=${WORKSPACE}/cegcc --parallelism $(nproc)
 
+# strip
+cd ${WORKSPACE}/cegcc
+find . | xargs file | grep "not stripped" | grep -oE '^[^:]+' | xargs strip
+
 # compress
 cd ${WORKSPACE}
 XZ_OPT="-T0" tar Jcf cegcc.tar.xz cegcc


### PR DESCRIPTION
CeGCC build script does not strip the binary by default. Let's strip them and reduce the container size!