### PR TITLE
fix arm-none-eabi-gcc path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ jobs:
       - run:
           name: check arm-none-eabi-gcc
           command: |
-            docker run -it --rm brainhackers/gen1_builder:latest /home/builder/arm-none-eabi/bin/arm-none-eabi-gcc -v
+            docker run -it --rm brainhackers/gen1_builder:latest /home/builder/x-tools/arm-none-eabi/bin/arm-none-eabi-gcc -v
 
   build_and_push_builder:
     machine:


### PR DESCRIPTION
I changed the toolchain path to pass CI.

- related links
    - https://app.circleci.com/pipelines/github/brain-hackers/docker-gen1-builder/35/workflows/c2d3d33f-909e-4ed4-8d71-51bb7f96efd4/jobs/179
    - https://github.com/brain-hackers/docker-gen1-builder/pull/8/files